### PR TITLE
Add category-specific extraction for text-heavy images

### DIFF
--- a/docs/IMAGE_CONTENT_EXTRACTION.md
+++ b/docs/IMAGE_CONTENT_EXTRACTION.md
@@ -1,6 +1,6 @@
 # Image Content Extraction Design & Implementation Plan
 
-> Last updated: 2024-12-24
+> Last updated: 2024-12-24 (added category-specific extraction prompts)
 
 ## Overview
 
@@ -85,7 +85,32 @@ Extend the existing media schema to include rich descriptions:
 media:
 - type: photo
   url: https://pbs.twimg.com/media/example.jpg
+  category: chart  # "text_heavy", "chart", or "general"
   description: "S&P 500 performance chart showing 15% YTD gains through Q3 2024. Key annotations highlight: (1) March dip correlating with banking concerns, (2) July rally following Fed pause, (3) Analyst note: 'Expecting consolidation before year-end push'. Chart style is candlestick with 50-day and 200-day moving averages overlaid."
+  extracted_at: 2024-12-24T10:30:00Z
+  extraction_model: claude-3-5-sonnet-20241022
+```
+
+**Example for text-heavy image (analyst note):**
+```yaml
+media:
+- type: photo
+  url: https://pbs.twimg.com/media/analyst_note.jpg
+  category: text_heavy
+  description: |
+    [TRANSCRIPTION]
+    Key Observations - Q4 2024:
+    1. Fed pivot confirmed - expect 3 cuts in 2025
+    2. Credit spreads tightening → risk-on environment
+    3. Watch: JPY carry trade unwind risk
+
+    Action items:
+    - Rotate from defensives to cyclicals
+    - Add duration to fixed income
+    - Hedge tail risk via VIX calls
+
+    [CONTEXT]
+    Handwritten analyst note on lined paper, appears to be meeting notes or personal research summary. Blue ink with some words underlined for emphasis.
   extracted_at: 2024-12-24T10:30:00Z
   extraction_model: claude-3-5-sonnet-20241022
 ```
@@ -202,6 +227,7 @@ Include image descriptions in the XML export format used for RAG context:
       "properties": {
         "type": {"type": "string", "enum": ["image", "photo", "video", "gif", "link"]},
         "url": {"type": "string", "format": "uri"},
+        "category": {"type": "string", "enum": ["text_heavy", "chart", "general"]},
         "description": {"type": "string"},
         "extracted_at": {"type": "string", "format": "date-time"},
         "extraction_model": {"type": "string"}
@@ -211,6 +237,11 @@ Include image descriptions in the XML export format used for RAG context:
   }
 }
 ```
+
+The `category` field enables:
+- Appropriate prompt selection during extraction
+- Filtering searches by image type (e.g., "find all chart posts")
+- Different display treatments in the frontend
 
 ---
 
@@ -306,32 +337,165 @@ class ImageContentExtractor:
                 "data": base64.standard_b64encode(response.content).decode("utf-8")
             }
 
-    def _build_prompt(self, post_context: Optional[str]) -> str:
-        """Build the extraction prompt."""
-        from .prompts import IMAGE_EXTRACTION_PROMPT
+    def _build_prompt(self, post_context: Optional[str], image_category: Optional[str] = None) -> str:
+        """Build the extraction prompt based on image category."""
+        from .prompts import get_extraction_prompt
 
+        prompt = get_extraction_prompt(image_category)
         if post_context:
-            return f"{IMAGE_EXTRACTION_PROMPT}\n\nContext from the post: {post_context}"
-        return IMAGE_EXTRACTION_PROMPT
+            return f"{prompt}\n\nContext from the post: {post_context}"
+        return prompt
+
+    async def describe_image(
+        self,
+        image_url: str,
+        post_context: Optional[str] = None,
+        image_category: Optional[str] = None  # "text_heavy", "chart", "general"
+    ) -> dict:
+        """
+        Generate a rich description of an image.
+
+        Args:
+            image_url: URL of the image to describe
+            post_context: The text of the post containing this image
+            image_category: Hint for extraction strategy. If None, auto-detects.
+
+        Returns:
+            Dict with 'description', 'category', and 'transcription' (if applicable)
+        """
+        image_data = await self._fetch_image(image_url)
+
+        # Auto-detect category if not provided
+        if image_category is None:
+            image_category = await self._detect_image_category(image_data, post_context)
+
+        prompt = self._build_prompt(post_context, image_category)
+
+        response = self.client.messages.create(
+            model=self.model_id,
+            max_tokens=2048,  # Increased for verbatim transcription
+            messages=[{
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": image_data["media_type"],
+                            "data": image_data["data"]
+                        }
+                    },
+                    {"type": "text", "text": prompt}
+                ]
+            }]
+        )
+
+        return {
+            "description": response.content[0].text,
+            "category": image_category
+        }
+
+    async def _detect_image_category(self, image_data: dict, post_context: Optional[str]) -> str:
+        """Use a quick vision call to classify the image type."""
+        response = self.client.messages.create(
+            model=self.model_id,
+            max_tokens=50,
+            messages=[{
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": image_data["media_type"],
+                            "data": image_data["data"]
+                        }
+                    },
+                    {
+                        "type": "text",
+                        "text": "Classify this image into ONE category: 'text_heavy' (screenshots, notes, documents with significant text), 'chart' (graphs, data visualizations, diagrams), or 'general' (photos, memes, other). Reply with only the category name."
+                    }
+                ]
+            }]
+        )
+        category = response.content[0].text.strip().lower()
+        if category not in ["text_heavy", "chart", "general"]:
+            category = "general"
+        return category
 ```
 
-#### 1.3 Extraction Prompts
+#### 1.3 Extraction Prompts (Category-Specific)
+
+The extraction strategy varies based on image type:
+
+| Category | Strategy | Output Focus |
+|----------|----------|--------------|
+| `text_heavy` | Verbatim transcription | Complete text content, preserving structure |
+| `chart` | Data extraction + interpretation | Numbers, trends, annotations, insights |
+| `general` | Semantic description | What's shown, context, relevance |
 
 ```python
 # src/vision/prompts.py
 
-IMAGE_EXTRACTION_PROMPT = """Describe this image in detail for a knowledge base system. Your description will be used for semantic search and RAG retrieval, so be thorough and precise.
+def get_extraction_prompt(category: Optional[str] = None) -> str:
+    """Return the appropriate extraction prompt for the image category."""
+    if category == "text_heavy":
+        return TEXT_HEAVY_PROMPT
+    elif category == "chart":
+        return CHART_PROMPT
+    else:
+        return GENERAL_PROMPT
+
+
+TEXT_HEAVY_PROMPT = """This image contains significant text content (screenshot, document, notes, etc.).
+
+Your task is to perform COMPLETE TEXT EXTRACTION. Transcribe ALL visible text verbatim.
+
+Requirements:
+1. **Full transcription**: Capture every word, number, and symbol visible
+2. **Preserve structure**: Maintain paragraph breaks, bullet points, headers, and formatting
+3. **Include annotations**: Handwritten notes, highlights, underlines, comments
+4. **Note context**: UI elements, timestamps, source indicators, watermarks
+
+Format your response as:
+---
+[TRANSCRIPTION]
+(Complete text content here, preserving structure)
+
+[CONTEXT]
+(Brief note on what type of document/screenshot this is and any relevant visual context)
+---
+
+Do NOT summarize. Capture the complete text content."""
+
+
+CHART_PROMPT = """This image contains a chart, graph, or data visualization.
+
+Extract both the DATA and the MEANING from this visualization.
 
 Include:
-1. **Literal content**: All visible text, numbers, labels, and data points
-2. **Visual structure**: Chart types, layouts, diagrams, flow directions
-3. **Key insights**: What the image conveys, argues, or demonstrates
-4. **Context clues**: Timestamps, sources, author annotations, watermarks
-5. **Relevant details**: Colors used meaningfully, highlighted areas, annotations
+1. **Chart type**: Line, bar, candlestick, pie, scatter, etc.
+2. **Axes and scales**: What's being measured, units, ranges
+3. **Key data points**: Important numbers, peaks, troughs, intersections
+4. **Trends**: Patterns, directions, correlations visible
+5. **Annotations**: Any text labels, callouts, or notes on the chart
+6. **Source/metadata**: Attribution, timestamps, data source if shown
 
-Be factual and descriptive. If the image contains a chart or data visualization, extract the key data points and trends. If it contains text (screenshots, notes), transcribe the important parts.
+Example format:
+"Candlestick chart of BTC/USD from Jan-Mar 2024. Y-axis: $38,000-$72,000. Key movements: (1) Jan 10 ETF approval spike from $46K to $49K, (2) Consolidation $41-43K through late Jan, (3) Breakout above $50K on Feb 12, (4) ATH $72,000 on Mar 14. Volume bars show heavy buying on breakout days. Annotation reads: 'Halving anticipation rally'. Source: TradingView."
 
-Keep your response concise but comprehensive - aim for 2-4 sentences for simple images, up to a paragraph for complex charts or infographics."""
+Be specific with numbers and dates when visible."""
+
+
+GENERAL_PROMPT = """Describe this image in detail for a knowledge base system. Your description will be used for semantic search and RAG retrieval.
+
+Include:
+1. **What's shown**: People, objects, scenes, actions
+2. **Any text**: Signs, captions, overlaid text, memes
+3. **Context**: What this image represents or communicates
+4. **Relevance**: Why someone might have saved this (insight, humor, reference)
+
+Be factual and descriptive. Aim for 2-4 sentences that capture what a human would take away from seeing this image."""
 ```
 
 ### Phase 2: Bot Integration
@@ -442,24 +606,37 @@ The existing migration script already reads from post files - it will automatica
 
 ### Per-Image Cost
 
-Using Claude 3.5 Sonnet for vision:
+Using Claude 3.5 Sonnet for vision (two calls per image):
+
+| Call | Input | Output | Purpose |
+|------|-------|--------|---------|
+| Classification | ~1,000-2,000 tokens (image) + 50 (prompt) | ~10 tokens | Detect image category |
+| Extraction | ~1,000-2,000 tokens (image) + 200-400 (prompt) | ~100-500 tokens | Full extraction |
 
 | Factor | Value |
 |--------|-------|
-| Input (image) | ~1,000-2,000 tokens typical |
-| Input (prompt) | ~200 tokens |
-| Output | ~100-300 tokens |
-| **Cost per image** | **~$0.005-$0.01** |
+| Classification call | ~$0.003 |
+| Extraction call | ~$0.005-$0.012 |
+| **Total per image** | **~$0.008-$0.015** |
+
+**Note:** For text-heavy images, output tokens may be higher (~500-1000) due to verbatim transcription, increasing cost to ~$0.02/image in those cases.
 
 ### Projected Costs
 
 | Scenario | Images | Cost |
 |----------|--------|------|
-| Backfill existing archive | ~50 posts × 1.5 images avg | ~$0.50-$1.00 |
-| Monthly new posts | ~30 posts × 1.5 images avg | ~$0.30-$0.60/month |
-| Annual ongoing | ~360 posts × 1.5 images avg | ~$4-$7/year |
+| Backfill existing archive | ~50 posts × 1.5 images avg | ~$0.75-$1.50 |
+| Monthly new posts | ~30 posts × 1.5 images avg | ~$0.50-$0.90/month |
+| Annual ongoing | ~360 posts × 1.5 images avg | ~$6-$11/year |
 
-**Conclusion:** Costs are minimal - less than a coffee per year.
+**Conclusion:** Costs are minimal - roughly a coffee per year.
+
+### Cost Optimization Options
+
+If classification overhead is a concern:
+- **Skip classification for known types**: If post text contains "chart", "graph", assume `chart` category
+- **Batch classification**: Classify multiple images in one call (if they're from the same post)
+- **Cache classification**: Similar images from same author may have consistent types
 
 ### Cost Controls
 


### PR DESCRIPTION
- Add auto-detection of image categories: text_heavy, chart, general
- TEXT_HEAVY_PROMPT: Verbatim transcription for analyst notes, screenshots
- CHART_PROMPT: Data extraction + interpretation for visualizations
- GENERAL_PROMPT: Semantic description for photos, memes
- Update schema to include 'category' field
- Update cost analysis for two-call approach (classify + extract)
- Add example showing full transcription of analyst note

This ensures analyst notes and other text-heavy images get complete verbatim transcription rather than summarization.